### PR TITLE
Remove puppet-lint-absolute_classname-check gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -22,7 +22,6 @@ Gemfile:
         version: '~> 2.5'
       - gem: rspec-puppet-facts
       - gem: rspec-puppet-utils
-      - gem: puppet-lint-absolute_classname-check
       - gem: puppet-lint-leading_zero-check
       - gem: puppet-lint-trailing_comma-check
       - gem: puppet-lint-version_comparison-check


### PR DESCRIPTION
This gem provided a test to check for problems with Puppet 3, which is not supported anymore.  Usage of this plugin is *not* recommended anymore.

https://github.com/voxpupuli/puppet-lint-absolute_classname-check