### PR TITLE
Exclude more files when building modules

### DIFF
--- a/moduleroot/.pmtignore.erb
+++ b/moduleroot/.pmtignore.erb
@@ -4,10 +4,12 @@ Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
+.fixtures.yml
 spec/fixtures/manifests/
 spec/fixtures/modules/
 .vagrant/
 .bundle/
+.env.sh
 .ruby-version
 coverage/
 log/
@@ -19,6 +21,17 @@ Puppetfile.lock
 .*.sw?
 .yardoc/
 Dockerfile
+.gitignore
+.git/
+.msync.yml
+.pmtignore
+.rspec
+.rspec_parallel
+.rubocop.yml
+.travis.yml
+.yardopts
+Jenkinsfile
+Vagrantfile
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>


### PR DESCRIPTION
Mainly exclude the .git directory which is huge, but also remove a bunch
of files not used by the module itself.